### PR TITLE
Add condition to display timeline ticks correctly for months

### DIFF
--- a/src/GanttTimeline.js
+++ b/src/GanttTimeline.js
@@ -159,12 +159,22 @@ export default class GanttTimeline extends Component {
     );
   }
 
-  renderTickLabel(tick, index) {
+  getTickTime(tick, index) {
     const { leftBound } = this.context;
-    const tickTime = moment(leftBound).add(
+    if(tick.unit === 'month'){
+      return moment(leftBound).add(
+        index,
+        'months'
+      );
+    }
+    return moment(leftBound).add(
       this.widthToDuration(tick.width) * index,
       'seconds'
     );
+  }
+
+  renderTickLabel(tick, index) {
+    const tickTime = this.getTickTime(tick, index);
     const format = this.getTimeFormat(tick.unit);
     return tickTime.format(format);
   }


### PR DESCRIPTION
The method widthToDuration(width) is intended to convert a given width in pixels to a duration in seconds. The pixel per second is calculated as timelineDuration / timelineWidth. In case of the timeline, which spans a year, the timeline duration is the total seconds of a year.

An issue arises due to the assumption that each month is exactly 1/12 of the year in terms of seconds. This is not the case in reality, as some months have 28, 29, 30, or 31 days, and hence varying numbers of seconds.

In the renderTickLabel(tick, index) method, you're using this.widthToDuration(tick.width) * index to calculate the time for each tick label. The width for each tick, however, is calculated with the assumption that each tick represents an equal duration, which in turn assumes each month is of equal duration.

As a result, when the width is converted back to a duration for labeling the ticks, the months that have more than the average number of days (i.e., 31-day months) appear twice, because the duration represented by the tick width is less than the actual duration of these months.

To address this issue, instead of using the widthToDuration() method to calculate the time for each tick, I calculate the time directly from the index of the tick in case of months.